### PR TITLE
Add location information to errors.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,7 +48,7 @@ main = do
             y = PrimTy NatTy
         in LollyTy (TupleTy (V.fromList [x, y])) (TupleTy (V.fromList [y, x]))
   putStrLn "> checking swap"
-  putStrLn $ runChecker $ check [] swapTy swap
+  putStrLn $ runChecker $ checkToplevel swapTy swap
 
 
   -- but this doesn't -- it duplicates its linear variable
@@ -56,12 +56,12 @@ main = do
         let x = PrimTy StringTy
         in LollyTy x (TupleTy (V.fromList [x, x]))
   putStrLn "> checking diagonal (expected failure due to duplicating linear variable)"
-  putStrLn $ runChecker $ check [] diagonalTy diagonal
+  putStrLn $ runChecker $ checkToplevel diagonalTy diagonal
 
   putStrLn "> checking case"
-  putStrLn $ runChecker $ check [] (PrimTy NatTy) caseExample'
+  putStrLn $ runChecker $ checkToplevel (PrimTy NatTy) caseExample'
   print $ evalC [] caseExample
 
   putStrLn "> checking primop"
-  putStrLn $ runChecker $ check [] (PrimTy StringTy) (Neu primopExample)
+  putStrLn $ runChecker $ checkToplevel (PrimTy StringTy) (Neu primopExample)
   print $ evalC [] primopExample


### PR DESCRIPTION
We use a zipper-inspired derivative data structure to indicate the
path we've taken to the error location.

Sample run:

```
> checking swap
success!
> checking diagonal (expected failure due to duplicating linear
> variable)
Lam'
Prd' 1
Neu'
BVar'

[useVar] used exhausted variable
> checking case
success!
Right (Primitive (Nat 1))
> checking primop
success!
Right (Primitive (String "abcxyz"))
```

Note that the messaging isn't very useful right now, but we can fix that
when we have pretty-printing. Nevertheless, it does indicate the actual
error location.
